### PR TITLE
Fix iOS overscroll white gap on iPad/iPhone browsers

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -119,7 +119,24 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    /* Prevent iOS overscroll white gap by setting black background */
+    background-color: #000;
+    /* Control overscroll behavior */
+    overscroll-behavior: none;
+    overscroll-behavior-y: none;
+    /* Ensure full height on iOS */
+    min-height: 100%;
+    min-height: 100dvh;
+  }
   body {
     @apply bg-background text-foreground;
+    /* Black background for iOS overscroll areas */
+    background-color: #000;
+    /* Prevent pull-to-refresh and overscroll gaps */
+    overscroll-behavior: none;
+    overscroll-behavior-y: none;
+    /* Use dynamic viewport height for iOS */
+    min-height: 100dvh;
   }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Space_Grotesk, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
@@ -34,6 +34,14 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  viewportFit: "cover", // Extends content into safe area for iOS
+  themeColor: "#000000", // Black theme color for browser chrome
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -42,7 +50,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} antialiased`}
+        className={`${spaceGrotesk.variable} ${jetbrainsMono.variable} antialiased bg-black`}
       >
         {children}
         <Analytics />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -40,9 +40,18 @@ export default function Home() {
   const { scale, gridMul, digitSize } = useResponsiveTerminalParams();
 
   return (
-    <div className="relative min-h-screen">
-      {/* Fixed terminal background */}
-      <div className="fixed inset-0" aria-hidden="true">
+    <div className="relative min-h-screen min-h-[100dvh]">
+      {/* Fixed terminal background - extended beyond viewport for iOS overscroll */}
+      <div
+        className="fixed bg-black"
+        style={{
+          top: "-100px",
+          right: "-100px",
+          bottom: "-100px",
+          left: "-100px",
+        }}
+        aria-hidden="true"
+      >
         <FaultyTerminal
           scale={scale}
           gridMul={gridMul}

--- a/apps/web/components/FaultyTerminal.css
+++ b/apps/web/components/FaultyTerminal.css
@@ -3,4 +3,5 @@
   height: 100%;
   position: relative;
   overflow: hidden;
+  background-color: #000;
 }


### PR DESCRIPTION
- Add black background to html/body to prevent white gap during overscroll
- Add overscroll-behavior: none to control iOS rubber-banding effect
- Use 100dvh (dynamic viewport height) for proper iOS viewport handling
- Extend fixed terminal background 100px beyond viewport in all directions
- Add viewport configuration with viewportFit: cover for iOS safe areas
- Set black theme color for browser chrome

https://claude.ai/code/session_019tfR7rHKdkeUnhz5SM2vuq