### PR TITLE
Fix WebGL background refresh on scroll

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -41,17 +41,8 @@ export default function Home() {
 
   return (
     <div className="relative min-h-screen min-h-[100dvh]">
-      {/* Fixed terminal background - extended beyond viewport for iOS overscroll */}
-      <div
-        className="fixed bg-black"
-        style={{
-          top: "-100px",
-          right: "-100px",
-          bottom: "-100px",
-          left: "-100px",
-        }}
-        aria-hidden="true"
-      >
+      {/* Fixed terminal background */}
+      <div className="fixed inset-0 bg-black" aria-hidden="true">
         <FaultyTerminal
           scale={scale}
           gridMul={gridMul}


### PR DESCRIPTION
Revert extended fixed container that was causing ResizeObserver to trigger during scroll, which reinitializes the WebGL rendering.

Use simpler inset-0 positioning with bg-black fallback. The CSS fixes in globals.css (black background on html/body + overscroll-behavior) handle the iOS overscroll white gap without needing to extend the container beyond viewport bounds.

https://claude.ai/code/session_019tfR7rHKdkeUnhz5SM2vuq