### PR TITLE
Align MCP tool schemas with backend types and implement bounty filtering

### DIFF
--- a/apps/mcp-server/src/services/task-service.ts
+++ b/apps/mcp-server/src/services/task-service.ts
@@ -22,6 +22,8 @@ export async function listTasksHandler(
   const { tasks, total } = await listTasks({
     status: input.status as any,
     tags: input.tags,
+    minBounty: input.minBounty,
+    maxBounty: input.maxBounty,
     limit: input.limit || 20,
     offset: input.offset || 0,
     sortBy,

--- a/apps/mcp-server/src/tools/agent/get-my-claims.ts
+++ b/apps/mcp-server/src/tools/agent/get-my-claims.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { getAgentClaimsHandler } from '../../services/claim-service';
 
 export const getMyClaimsSchema = z.object({
-  status: z.enum(['active', 'submitted', 'approved', 'rejected']).optional(),
+  status: z.enum(['active', 'submitted', 'under_verification', 'approved', 'rejected', 'abandoned', 'expired']).optional(),
   limit: z.number().min(1).max(100).default(20),
 });
 
@@ -16,7 +16,7 @@ export const getMyClaimsTool = {
     properties: {
       status: {
         type: 'string',
-        enum: ['active', 'submitted', 'approved', 'rejected'],
+        enum: ['active', 'submitted', 'under_verification', 'approved', 'rejected', 'abandoned', 'expired'],
         description: 'Filter by claim status',
       },
       limit: {

--- a/apps/mcp-server/src/tools/task/list-tasks.ts
+++ b/apps/mcp-server/src/tools/task/list-tasks.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { listTasksHandler } from '../../services/task-service';
 
 export const listTasksSchema = z.object({
-  status: z.enum(['open', 'claimed', 'submitted', 'completed']).optional(),
+  status: z.enum(['open', 'claimed', 'submitted', 'under_verification', 'completed', 'disputed', 'cancelled', 'expired']).optional(),
   tags: z.array(z.string()).optional(),
   minBounty: z.string().optional(),
   maxBounty: z.string().optional(),
@@ -22,7 +22,7 @@ export const listTasksTool = {
     properties: {
       status: {
         type: 'string',
-        enum: ['open', 'claimed', 'submitted', 'completed'],
+        enum: ['open', 'claimed', 'submitted', 'under_verification', 'completed', 'disputed', 'cancelled', 'expired'],
         description: 'Filter by task status',
       },
       tags: {

--- a/apps/mcp-server/src/tools/verifier/submit-verdict.ts
+++ b/apps/mcp-server/src/tools/verifier/submit-verdict.ts
@@ -6,7 +6,7 @@ import { getTaskHandler } from '../../services/task-service';
 export const submitVerdictSchema = z.object({
   taskId: z.string().min(1),
   claimId: z.string().min(1),
-  outcome: z.enum(['approved', 'rejected', 'revision_requested']),
+  outcome: z.enum(['approved', 'rejected', 'revision_requested', 'escalated']),
   score: z.number().min(0).max(100),
   feedback: z.string().min(1),
   recommendations: z.array(z.string()).optional(),
@@ -31,7 +31,7 @@ export const submitVerdictTool = {
       },
       outcome: {
         type: 'string',
-        enum: ['approved', 'rejected', 'revision_requested'],
+        enum: ['approved', 'rejected', 'revision_requested', 'escalated'],
         description: 'Verification outcome',
       },
       score: {
@@ -113,7 +113,9 @@ export const submitVerdictTool = {
       ? 'approved'
       : input.outcome === 'rejected'
         ? 'rejected'
-        : 'active'; // revision_requested goes back to active
+        : input.outcome === 'escalated'
+          ? 'under_verification' // escalated keeps claim under verification for dispute resolution
+          : 'active'; // revision_requested goes back to active
 
     await updateClaim(input.claimId, {
       status: newClaimStatus,

--- a/packages/database/src/queries/task-queries.ts
+++ b/packages/database/src/queries/task-queries.ts
@@ -31,6 +31,8 @@ export async function listTasks(options: ListTasksOptions = {}): Promise<{
     creatorAddress,
     claimedBy,
     tags,
+    minBounty,
+    maxBounty,
     limit = 20,
     offset = 0,
     sortBy = 'created_at',
@@ -53,6 +55,14 @@ export async function listTasks(options: ListTasksOptions = {}): Promise<{
 
   if (tags && tags.length > 0) {
     query = query.overlaps('tags', tags);
+  }
+
+  if (minBounty) {
+    query = query.gte('bounty_amount', minBounty);
+  }
+
+  if (maxBounty) {
+    query = query.lte('bounty_amount', maxBounty);
   }
 
   query = query

--- a/packages/shared-types/src/mcp/tool-inputs.ts
+++ b/packages/shared-types/src/mcp/tool-inputs.ts
@@ -6,7 +6,7 @@
 // Task tools
 export interface ListTasksInput {
   /** Filter by status */
-  status?: 'open' | 'claimed' | 'submitted' | 'completed';
+  status?: 'open' | 'claimed' | 'submitted' | 'under_verification' | 'completed' | 'disputed' | 'cancelled' | 'expired';
   /** Filter by tags */
   tags?: string[];
   /** Filter by minimum bounty (in ETH) */
@@ -84,7 +84,7 @@ export interface SubmitWorkInput {
 
 export interface GetMyClaimsInput {
   /** Filter by status */
-  status?: 'active' | 'submitted' | 'approved' | 'rejected';
+  status?: 'active' | 'submitted' | 'under_verification' | 'approved' | 'rejected' | 'abandoned' | 'expired';
   /** Number of results */
   limit?: number;
 }
@@ -103,7 +103,7 @@ export interface SubmitVerdictInput {
   /** Claim ID */
   claimId: string;
   /** Verdict outcome */
-  outcome: 'approved' | 'rejected' | 'revision_requested';
+  outcome: 'approved' | 'rejected' | 'revision_requested' | 'escalated';
   /** Overall score (0-100) */
   score: number;
   /** Detailed feedback */

--- a/packages/shared-types/src/verification/feedback.ts
+++ b/packages/shared-types/src/verification/feedback.ts
@@ -13,7 +13,7 @@ export interface VerificationFeedback {
   claimId: string;
 
   /** Overall verdict */
-  verdict: 'approved' | 'rejected' | 'revision_requested';
+  verdict: 'approved' | 'rejected' | 'revision_requested' | 'escalated';
 
   /** Overall score (0-100) */
   score: number;


### PR DESCRIPTION
- Add all TaskStatus values to list_tasks tool (open, claimed, submitted,
  under_verification, completed, disputed, cancelled, expired)
- Add all ClaimStatus values to get_my_claims tool (active, submitted,
  under_verification, approved, rejected, abandoned, expired)
- Add 'escalated' outcome to submit_verdict tool for dispute resolution
- Implement minBounty/maxBounty filtering in task-queries.ts
- Pass bounty filters from task-service to database queries
- Update shared-types tool-inputs.ts and feedback.ts for consistency

https://claude.ai/code/session_01XPBxH4v1FMzEyJJpjsomKB