### PR TITLE
Update social meta tags with Space Grotesk font and explicit images

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -23,11 +23,20 @@ export const metadata: Metadata = {
     url: "https://porternetwork.vercel.app",
     siteName: "Porter Network",
     type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Porter Network - The agent economy starts here",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Porter Network",
     description: "The agent economy starts here",
+    images: ["/twitter-image"],
   },
   robots: {
     index: true,

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -10,6 +10,13 @@ export const size = {
 export const contentType = "image/png";
 
 export default async function Image() {
+  // Load Space Grotesk Bold font from Google Fonts
+  const spaceGroteskBold = await fetch(
+    new URL(
+      "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+    )
+  ).then((res) => res.arrayBuffer());
+
   return new ImageResponse(
     (
       <div
@@ -21,7 +28,6 @@ export default async function Image() {
           alignItems: "center",
           justifyContent: "center",
           backgroundColor: "#000000",
-          padding: "40px 80px",
         }}
       >
         <div
@@ -30,37 +36,44 @@ export default async function Image() {
             flexDirection: "column",
             alignItems: "center",
             justifyContent: "center",
-            gap: "24px",
           }}
         >
-          <h1
+          <div
             style={{
-              fontSize: "72px",
+              fontSize: 80,
               fontWeight: 700,
               color: "#ffffff",
-              textAlign: "center",
-              margin: 0,
-              letterSpacing: "-0.02em",
+              letterSpacing: "-0.025em",
+              fontFamily: "Space Grotesk",
+              lineHeight: 1.1,
             }}
           >
             Porter Network
-          </h1>
-          <p
+          </div>
+          <div
             style={{
-              fontSize: "32px",
+              fontSize: 32,
               fontWeight: 400,
-              color: "#a1a1aa",
-              textAlign: "center",
-              margin: 0,
+              color: "rgba(255, 255, 255, 0.6)",
+              marginTop: 20,
+              fontFamily: "Space Grotesk",
             }}
           >
             The agent economy starts here
-          </p>
+          </div>
         </div>
       </div>
     ),
     {
       ...size,
+      fonts: [
+        {
+          name: "Space Grotesk",
+          data: spaceGroteskBold,
+          style: "normal",
+          weight: 700,
+        },
+      ],
     }
   );
 }

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -10,6 +10,13 @@ export const size = {
 export const contentType = "image/png";
 
 export default async function Image() {
+  // Load Space Grotesk Bold font from Google Fonts
+  const spaceGroteskBold = await fetch(
+    new URL(
+      "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+    )
+  ).then((res) => res.arrayBuffer());
+
   return new ImageResponse(
     (
       <div
@@ -21,7 +28,6 @@ export default async function Image() {
           alignItems: "center",
           justifyContent: "center",
           backgroundColor: "#000000",
-          padding: "40px 80px",
         }}
       >
         <div
@@ -30,37 +36,44 @@ export default async function Image() {
             flexDirection: "column",
             alignItems: "center",
             justifyContent: "center",
-            gap: "24px",
           }}
         >
-          <h1
+          <div
             style={{
-              fontSize: "72px",
+              fontSize: 80,
               fontWeight: 700,
               color: "#ffffff",
-              textAlign: "center",
-              margin: 0,
-              letterSpacing: "-0.02em",
+              letterSpacing: "-0.025em",
+              fontFamily: "Space Grotesk",
+              lineHeight: 1.1,
             }}
           >
             Porter Network
-          </h1>
-          <p
+          </div>
+          <div
             style={{
-              fontSize: "32px",
+              fontSize: 32,
               fontWeight: 400,
-              color: "#a1a1aa",
-              textAlign: "center",
-              margin: 0,
+              color: "rgba(255, 255, 255, 0.6)",
+              marginTop: 20,
+              fontFamily: "Space Grotesk",
             }}
           >
             The agent economy starts here
-          </p>
+          </div>
         </div>
       </div>
     ),
     {
       ...size,
+      fonts: [
+        {
+          name: "Space Grotesk",
+          data: spaceGroteskBold,
+          style: "normal",
+          weight: 700,
+        },
+      ],
     }
   );
 }


### PR DESCRIPTION
- Add Space Grotesk font to OG and Twitter images for landing page consistency
- Add explicit twitter:images and openGraph.images in metadata
- Twitter requires explicit twitter:image tag (doesn't reliably fall back to OG)

https://claude.ai/code/session_01BVN3oHmGHXBULYUoS97MA9