### PR TITLE
Fix OpenGraph and Twitter image generation

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -36,7 +36,14 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Porter Network",
     description: "The agent economy starts here",
-    images: ["/twitter-image"],
+    images: [
+      {
+        url: "/twitter-image",
+        width: 1200,
+        height: 630,
+        alt: "Porter Network - The agent economy starts here",
+      },
+    ],
   },
   robots: {
     index: true,

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -10,12 +10,19 @@ export const size = {
 export const contentType = "image/png";
 
 export default async function Image() {
-  // Load Space Grotesk Bold font from Google Fonts
-  const spaceGroteskBold = await fetch(
-    new URL(
-      "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
-    )
-  ).then((res) => res.arrayBuffer());
+  // Load Space Grotesk fonts from Google Fonts
+  const [spaceGroteskBold, spaceGroteskRegular] = await Promise.all([
+    fetch(
+      new URL(
+        "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+      )
+    ).then((res) => res.arrayBuffer()),
+    fetch(
+      new URL(
+        "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEg.woff2"
+      )
+    ).then((res) => res.arrayBuffer()),
+  ]);
 
   return new ImageResponse(
     (
@@ -72,6 +79,12 @@ export default async function Image() {
           data: spaceGroteskBold,
           style: "normal",
           weight: 700,
+        },
+        {
+          name: "Space Grotesk",
+          data: spaceGroteskRegular,
+          style: "normal",
+          weight: 400,
         },
       ],
     }

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -10,12 +10,19 @@ export const size = {
 export const contentType = "image/png";
 
 export default async function Image() {
-  // Load Space Grotesk Bold font from Google Fonts
-  const spaceGroteskBold = await fetch(
-    new URL(
-      "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
-    )
-  ).then((res) => res.arrayBuffer());
+  // Load Space Grotesk fonts from Google Fonts
+  const [spaceGroteskBold, spaceGroteskRegular] = await Promise.all([
+    fetch(
+      new URL(
+        "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2"
+      )
+    ).then((res) => res.arrayBuffer()),
+    fetch(
+      new URL(
+        "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEg.woff2"
+      )
+    ).then((res) => res.arrayBuffer()),
+  ]);
 
   return new ImageResponse(
     (
@@ -72,6 +79,12 @@ export default async function Image() {
           data: spaceGroteskBold,
           style: "normal",
           weight: 700,
+        },
+        {
+          name: "Space Grotesk",
+          data: spaceGroteskRegular,
+          style: "normal",
+          weight: 400,
         },
       ],
     }


### PR DESCRIPTION
- Load both font weights (400 and 700) for proper text rendering
- Update Twitter metadata to use explicit image object with dimensions
- Subtitle was using fontWeight 400 but only 700 was loaded

https://claude.ai/code/session_01RdaAWbS7LP9HABLTenEnHK