### PR TITLE
Add OpenGraph and Twitter social meta tags

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -22,39 +22,53 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://clawboy.vercel.app'),
-  title: 'Clawboy',
-  description: 'The agent economy starts here',
+  title: {
+    default: 'Clawboy - Work for agents',
+    template: '%s | Clawboy',
+  },
+  description: 'A task marketplace where AI agents earn bounties. Browse tasks, submit work, get paid on-chain.',
+  keywords: ['AI agents', 'task marketplace', 'bounties', 'blockchain', 'MCP', 'autonomous agents', 'Base L2'],
+  authors: [{ name: 'Clawboy' }],
+  creator: 'Clawboy',
   openGraph: {
-    title: 'Clawboy',
-    description: 'Post tasks. Complete work. Verify quality. All autonomous.',
+    title: 'Clawboy - Work for agents',
+    description: 'A task marketplace where AI agents earn bounties. Browse tasks, submit work, get paid on-chain.',
     url: 'https://clawboy.vercel.app',
     siteName: 'Clawboy',
     type: 'website',
+    locale: 'en_US',
     images: [
       {
         url: '/opengraph-image',
         width: 1200,
         height: 630,
-        alt: 'Clawboy - The agent economy starts here',
+        alt: 'Clawboy - Work for agents',
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Clawboy',
-    description: 'The agent economy starts here',
+    title: 'Clawboy - Work for agents',
+    description: 'A task marketplace where AI agents earn bounties. Browse tasks, submit work, get paid on-chain.',
     images: [
       {
         url: '/twitter-image',
         width: 1200,
         height: 630,
-        alt: 'Clawboy - The agent economy starts here',
+        alt: 'Clawboy - Work for agents',
       },
     ],
   },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
   },
 };
 

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
 
-export const alt = 'Clawboy - The agent economy starts here';
+export const alt = 'Clawboy - Work for agents';
 export const size = {
   width: 1200,
   height: 630,
@@ -10,15 +10,15 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  // Load Space Grotesk fonts from Google Fonts
-  const [spaceGroteskBold, spaceGroteskRegular] = await Promise.all([
-    fetch(
-      new URL('https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2')
-    ).then((res) => res.arrayBuffer()),
+  // Load Zilla Slab (heading) and Archivo (body) fonts from Google Fonts
+  const [zillaSlabBold, archivoRegular] = await Promise.all([
     fetch(
       new URL(
-        'https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEg.woff2'
+        'https://fonts.gstatic.com/s/zillaslab/v11/dFa5ZfeM_74wlPZtksIFajo6_V6LVlA.woff2'
       )
+    ).then((res) => res.arrayBuffer()),
+    fetch(
+      new URL('https://fonts.gstatic.com/s/archivo/v19/k3kQo8UDI-1M0wlSTd7iL0nAMaM.woff2')
     ).then((res) => res.arrayBuffer()),
   ]);
 
@@ -31,39 +31,92 @@ export default async function Image() {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: '#000000',
+        // Dark mode background: deep blue-gray (#0d1117)
+        backgroundColor: '#0d1117',
+        position: 'relative',
       }}
     >
+      {/* Subtle gradient glow effect */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '60%',
+          background:
+            'radial-gradient(ellipse 80% 50% at 50% 0%, rgba(56, 68, 89, 0.4), transparent 60%)',
+        }}
+      />
+
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
+          zIndex: 1,
         }}
       >
+        {/* Main headline */}
         <div
           style={{
-            fontSize: 80,
+            fontSize: 72,
             fontWeight: 700,
-            color: '#ffffff',
-            letterSpacing: '-0.025em',
-            fontFamily: 'Space Grotesk',
+            color: '#f0f6fc',
+            letterSpacing: '-0.02em',
+            fontFamily: 'Zilla Slab',
             lineHeight: 1.1,
           }}
         >
-          Clawboy
+          Work for agents
         </div>
+
+        {/* Tagline */}
         <div
           style={{
-            fontSize: 32,
+            fontSize: 28,
             fontWeight: 400,
-            color: 'rgba(255, 255, 255, 0.6)',
-            marginTop: 20,
-            fontFamily: 'Space Grotesk',
+            color: 'rgba(240, 246, 252, 0.6)',
+            marginTop: 24,
+            fontFamily: 'Archivo',
+            maxWidth: 700,
+            textAlign: 'center',
+            lineHeight: 1.4,
           }}
         >
-          The agent economy starts here
+          A task marketplace where AI agents earn bounties
+        </div>
+
+        {/* Brand */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginTop: 48,
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 24,
+              fontWeight: 700,
+              color: '#58a6ff',
+              fontFamily: 'Zilla Slab',
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Clawboy
+          </div>
+          <div
+            style={{
+              fontSize: 18,
+              color: 'rgba(240, 246, 252, 0.4)',
+              fontFamily: 'Archivo',
+            }}
+          >
+            clawboy.vercel.app
+          </div>
         </div>
       </div>
     </div>,
@@ -71,14 +124,14 @@ export default async function Image() {
       ...size,
       fonts: [
         {
-          name: 'Space Grotesk',
-          data: spaceGroteskBold,
+          name: 'Zilla Slab',
+          data: zillaSlabBold,
           style: 'normal',
           weight: 700,
         },
         {
-          name: 'Space Grotesk',
-          data: spaceGroteskRegular,
+          name: 'Archivo',
+          data: archivoRegular,
           style: 'normal',
           weight: 400,
         },

--- a/apps/web/app/twitter-image.tsx
+++ b/apps/web/app/twitter-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
 
-export const alt = 'Clawboy - The agent economy starts here';
+export const alt = 'Clawboy - Work for agents';
 export const size = {
   width: 1200,
   height: 630,
@@ -10,15 +10,15 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  // Load Space Grotesk fonts from Google Fonts
-  const [spaceGroteskBold, spaceGroteskRegular] = await Promise.all([
-    fetch(
-      new URL('https://fonts.gstatic.com/s/spacegrotesk/v16/V8mDoQDjQSkFtoMM3T6r8E7mPbF4Cw.woff2')
-    ).then((res) => res.arrayBuffer()),
+  // Load Zilla Slab (heading) and Archivo (body) fonts from Google Fonts
+  const [zillaSlabBold, archivoRegular] = await Promise.all([
     fetch(
       new URL(
-        'https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEg.woff2'
+        'https://fonts.gstatic.com/s/zillaslab/v11/dFa5ZfeM_74wlPZtksIFajo6_V6LVlA.woff2'
       )
+    ).then((res) => res.arrayBuffer()),
+    fetch(
+      new URL('https://fonts.gstatic.com/s/archivo/v19/k3kQo8UDI-1M0wlSTd7iL0nAMaM.woff2')
     ).then((res) => res.arrayBuffer()),
   ]);
 
@@ -31,39 +31,92 @@ export default async function Image() {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: '#000000',
+        // Dark mode background: deep blue-gray (#0d1117)
+        backgroundColor: '#0d1117',
+        position: 'relative',
       }}
     >
+      {/* Subtle gradient glow effect */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '60%',
+          background:
+            'radial-gradient(ellipse 80% 50% at 50% 0%, rgba(56, 68, 89, 0.4), transparent 60%)',
+        }}
+      />
+
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
           justifyContent: 'center',
+          zIndex: 1,
         }}
       >
+        {/* Main headline */}
         <div
           style={{
-            fontSize: 80,
+            fontSize: 72,
             fontWeight: 700,
-            color: '#ffffff',
-            letterSpacing: '-0.025em',
-            fontFamily: 'Space Grotesk',
+            color: '#f0f6fc',
+            letterSpacing: '-0.02em',
+            fontFamily: 'Zilla Slab',
             lineHeight: 1.1,
           }}
         >
-          Clawboy
+          Work for agents
         </div>
+
+        {/* Tagline */}
         <div
           style={{
-            fontSize: 32,
+            fontSize: 28,
             fontWeight: 400,
-            color: 'rgba(255, 255, 255, 0.6)',
-            marginTop: 20,
-            fontFamily: 'Space Grotesk',
+            color: 'rgba(240, 246, 252, 0.6)',
+            marginTop: 24,
+            fontFamily: 'Archivo',
+            maxWidth: 700,
+            textAlign: 'center',
+            lineHeight: 1.4,
           }}
         >
-          The agent economy starts here
+          A task marketplace where AI agents earn bounties
+        </div>
+
+        {/* Brand */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginTop: 48,
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 24,
+              fontWeight: 700,
+              color: '#58a6ff',
+              fontFamily: 'Zilla Slab',
+              letterSpacing: '-0.01em',
+            }}
+          >
+            Clawboy
+          </div>
+          <div
+            style={{
+              fontSize: 18,
+              color: 'rgba(240, 246, 252, 0.4)',
+              fontFamily: 'Archivo',
+            }}
+          >
+            clawboy.vercel.app
+          </div>
         </div>
       </div>
     </div>,
@@ -71,14 +124,14 @@ export default async function Image() {
       ...size,
       fonts: [
         {
-          name: 'Space Grotesk',
-          data: spaceGroteskBold,
+          name: 'Zilla Slab',
+          data: zillaSlabBold,
           style: 'normal',
           weight: 700,
         },
         {
-          name: 'Space Grotesk',
-          data: spaceGroteskRegular,
+          name: 'Archivo',
+          data: archivoRegular,
           style: 'normal',
           weight: 400,
         },


### PR DESCRIPTION
- Update OG/Twitter images to match landing page style
  - Use Zilla Slab + Archivo fonts
  - Dark blue-gray background (#0d1117)
  - Subtle gradient glow effect
  - "Work for agents" headline with tagline
- Enhance metadata in layout.tsx
  - Add title template for page titles
  - Add keywords and author metadata
  - Add locale and enhanced robot directives
  - Update descriptions to match hero section

https://claude.ai/code/session_01Vx2miMQqaasuGUVRbMazva