### PR TITLE
Fix IPFS CID validation and improve retry error handling

### DIFF
--- a/packages/ipfs-utils/src/client/pinata-client.ts
+++ b/packages/ipfs-utils/src/client/pinata-client.ts
@@ -58,11 +58,18 @@ export async function getSignedGatewayUrl(
 
 /**
  * Check if a CID is valid
+ *
+ * CIDv0: Starts with "Qm", base58btc encoded, exactly 46 characters
+ * CIDv1: Starts with "b", base32lower encoded, variable length (typically 50-64 chars)
+ *        Uses only base32 alphabet: a-z and 2-7 (no 0, 1, 8, 9)
  */
 export function isValidCid(cid: string): boolean {
-  // Basic CID validation (v0 or v1)
+  // CIDv0: Qm + 44 base58 characters = 46 total
   const cidV0Regex = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/;
-  const cidV1Regex = /^b[a-z2-7]{58}$/;
+
+  // CIDv1 base32lower: b + 32-100 base32 characters (allows various codecs/hashes)
+  // Base32 alphabet is [a-z2-7] - numbers 0, 1, 8, 9 are NOT valid
+  const cidV1Regex = /^b[a-z2-7]{32,100}$/;
 
   return cidV0Regex.test(cid) || cidV1Regex.test(cid);
 }


### PR DESCRIPTION
- Update CIDv1 regex to accept variable-length CIDs (32-100 chars) instead
  of requiring exactly 58 chars, supporting various codecs/hash algorithms
- Add pre-validation in IPFS retry job to detect invalid CID formats early
- Log permanent failures (invalid CID format) at error level with clear
  messaging to distinguish from transient network failures
- Skip unnecessary fetch attempts for permanently invalid CIDs

The test CID "bafkreie2e4e2e4testspec12345" correctly fails validation
because it contains digits 1,4,5 which are not in the base32 alphabet.

https://claude.ai/code/session_01NcVbCapFuJDJMCNxEPDB5R