### PR TITLE
fix(indexer): chunk eth_getLogs to MAX_BLOCK_RANGE (2000) per poll

### DIFF
--- a/apps/indexer/src/__tests__/listener.test.ts
+++ b/apps/indexer/src/__tests__/listener.test.ts
@@ -347,4 +347,58 @@ describe('createEventListener', () => {
     listener.stop();
     expect(listener.getLastProcessedBlock()).toBe(500n);
   });
+
+  test('chunks getLogs queries when block gap exceeds MAX_BLOCK_RANGE', async () => {
+    // Public RPCs (e.g. sepolia.base.org) cap eth_getLogs at 2000 blocks per call.
+    // The listener must cap each getLogs request even when the gap is larger,
+    // otherwise the RPC rejects every query and the indexer never recovers.
+    mockDb.getLastSyncedBlock.mockImplementation(() => Promise.resolve(1000n));
+    mockBlockNumber = 10_000n; // gap of 8999 blocks, well above the 2000 limit
+    mockWeb3.mockGetLogs.mockImplementation(() => Promise.resolve([]));
+
+    const listener = createEventListener(84532, 100000);
+    listener.onEvent(mock(() => Promise.resolve()));
+    listener.start();
+    await new Promise((r) => setTimeout(r, 100));
+    listener.stop();
+
+    // Inspect the toBlock arg passed to every getLogs call this poll cycle made.
+    const calls = mockWeb3.mockGetLogs.mock.calls as Array<[{ fromBlock: bigint; toBlock: bigint }]>;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [arg] of calls) {
+      const span = arg.toBlock - arg.fromBlock + 1n;
+      expect(span).toBeLessThanOrEqual(2000n);
+    }
+
+    // Single poll should not jump straight to currentBlock when the gap is huge --
+    // it advances by at most MAX_BLOCK_RANGE so the next poll picks up the rest.
+    expect(listener.getLastProcessedBlock()).toBeLessThan(10_000n);
+    expect(listener.getLastProcessedBlock()).toBeGreaterThanOrEqual(1000n + 2000n);
+  });
+
+  test('catches up across multiple polls when gap > MAX_BLOCK_RANGE', async () => {
+    // After enough poll cycles, the indexer should drain a backlog and approach currentBlock.
+    // Use a slowly-growing currentBlock so the catch-up logic exercises the chunking
+    // path on every poll without ever hitting the reorg detector at the head.
+    mockDb.getLastSyncedBlock.mockImplementation(() => Promise.resolve(1000n));
+    let head = 8_000n; // gap of 6999 -> ~4 chunks of <=2000
+    mockWeb3.getBlockNumber.mockImplementation(() => {
+      const v = head;
+      head += 10n; // mimic ~10 new blocks per poll so we never fully catch the head
+      return Promise.resolve(v);
+    });
+    mockWeb3.mockGetLogs.mockImplementation(() => Promise.resolve([]));
+
+    const listener = createEventListener(84532, 20); // fast polling for this test
+    listener.onEvent(mock(() => Promise.resolve()));
+    listener.start();
+    await new Promise((r) => setTimeout(r, 500));
+    listener.stop();
+
+    // Should have progressed well past the starting checkpoint of 1000.
+    // With ~25 polls and 2000-block chunks, we expect to be near (but possibly
+    // not exactly at) the current head -- the important thing is monotonic progress.
+    const final = listener.getLastProcessedBlock();
+    expect(final).toBeGreaterThan(3_000n);
+  });
 });

--- a/apps/indexer/src/listener.ts
+++ b/apps/indexer/src/listener.ts
@@ -111,6 +111,17 @@ export function createEventListener(
         return;
       }
 
+      // Cap the query range to MAX_BLOCK_RANGE per poll. Public RPCs
+      // (e.g. sepolia.base.org) reject eth_getLogs requests spanning more than
+      // 2000 blocks with `-32602: query exceeds max block range 2000`. Without
+      // this cap, an indexer that falls behind by >2000 blocks (e.g. after a
+      // restart) would have every poll fail and the lag would grow forever.
+      // By capping per-poll progress, the listener catches up across multiple
+      // poll cycles, advancing by up to MAX_BLOCK_RANGE each cycle.
+      const MAX_BLOCK_RANGE = 2000n;
+      const maxToBlock = fromBlock + MAX_BLOCK_RANGE - 1n;
+      const toBlock = currentBlock < maxToBlock ? currentBlock : maxToBlock;
+
       // ============ TaskManagerV2 Events ============
 
       // TaskCreated (V2: includes requiredWorkers, requiredJudges, workDeadline, judgeDeadline)
@@ -132,7 +143,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // WorkSubmitted (V2: worker instead of agent, slotIndex instead of submissionIndex)
@@ -149,7 +160,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // JudgmentSubmitted (V2 new event)
@@ -165,7 +176,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // PhaseChanged (V2 new event)
@@ -181,7 +192,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // TaskResolved (V2 new event)
@@ -198,7 +209,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // TaskFailed (V2 new event)
@@ -213,7 +224,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // TaskCancelled (unchanged from V1)
@@ -228,7 +239,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // ============ PactAgentAdapter Events (ERC-8004) ============
@@ -246,7 +257,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // AgentProfileUpdated (from ERC-8004 adapter)
@@ -262,7 +273,7 @@ export function createEventListener(
           ],
         },
         fromBlock,
-        toBlock: currentBlock,
+        toBlock,
       });
 
       // Process all events
@@ -307,15 +318,18 @@ export function createEventListener(
         }
       }
 
-      lastProcessedBlock = currentBlock;
+      // Advance to the chunked toBlock, not currentBlock. If the gap exceeded
+      // MAX_BLOCK_RANGE, the next poll picks up from toBlock+1 and continues
+      // catching up until lastProcessedBlock == currentBlock.
+      lastProcessedBlock = toBlock;
       completedInitialSync = true;
 
-      // Final checkpoint to currentBlock (may be ahead of last event block)
-      if (currentBlock > lastCheckpointedBlock) {
+      // Final checkpoint to toBlock (may be ahead of last event block within this chunk)
+      if (toBlock > lastCheckpointedBlock) {
         try {
           await Promise.all([
-            updateSyncState(chainId, addresses.taskManager, currentBlock),
-            updateSyncState(chainId, addresses.agentAdapter, currentBlock),
+            updateSyncState(chainId, addresses.taskManager, toBlock),
+            updateSyncState(chainId, addresses.agentAdapter, toBlock),
           ]);
         } catch (error) {
           console.warn('Failed to save final checkpoint:', error);
@@ -323,7 +337,7 @@ export function createEventListener(
       }
 
       if (allEvents.length > 0) {
-        console.log(`Processed ${allEvents.length} events up to block ${currentBlock}`);
+        console.log(`Processed ${allEvents.length} events up to block ${toBlock}`);
       }
     } catch (error) {
       console.error('Error polling events:', error);


### PR DESCRIPTION
## Summary

Public Base Sepolia RPC (`sepolia.base.org`) caps `eth_getLogs` at 2000 blocks per call. If the indexer falls behind by more than that (e.g. container offline > ~67 min), `pollEvents` issued a single query spanning the entire gap and the RPC rejected it with `-32602: query exceeds max block range`.

The catch in `pollEvents` swallowed the error without advancing the checkpoint, so once unhealthy the indexer never recovered: `lagBlocks` grew monotonically and `/health` returned 503 forever.

This change caps each poll's range at `MAX_BLOCK_RANGE` (2000) so large backlogs are drained across multiple polls. `lastProcessedBlock` and the final checkpoint now advance to the chunked `toBlock` rather than `currentBlock`.

## Changes

- `apps/indexer/src/listener.ts` — 9 `getLogs` calls + final-checkpoint logic switched from `currentBlock` → chunked `toBlock`; new `MAX_BLOCK_RANGE` constant
- `apps/indexer/src/__tests__/listener.test.ts` — two new tests (chunking enforced; multi-poll catch-up)

## Verification

- Verified live on OCI ARM: with ~65k blocks of lag the indexer caught up to <200 lag in ~5 minutes and Docker reported `(healthy)`
- New tests pass locally: `bun test src/__tests__/listener.test.ts` → 21/22 pass (the 1 failure — `resumes from minimum checkpoint across contracts` at line 78 — is **pre-existing on `main`** and unrelated to this change)

## Test plan

- [ ] CI green on the new tests
- [ ] Manual: stop indexer, wait > 67 min, restart, confirm it catches up across multiple polls instead of erroring